### PR TITLE
fixed issue where monster levels were displaying as N/A

### DIFF
--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -31,7 +31,7 @@ const Search = () => {
               <p><strong>Description:</strong> {card.desc}</p>
               <p><strong>Attack:</strong> {card.atk != null ? card.atk : 'N/A'}</p>
               <p><strong>Defense:</strong> {card.def != null ? card.def : 'N/A'}</p>
-              <p><strong>Level:</strong> {card.leve != null ? card.level : 'N/A'}</p>
+              <p><strong>Level:</strong> {card.level != null && card.level !== 0 ? card.level : 'N/A'}</p>
               <p><strong>Attribute:</strong> {card.attribute != null ? card.attribute : 'N/A'}</p>
               <button>Add to Collection</button>
             </li>))}


### PR DESCRIPTION
This issue was affecting Monster Cards that had a valid level and was still displaying N/A. This issue has now been fixed and N/A is only applied to cards without a value or where the value of the level is equivalent of 0